### PR TITLE
README: introduce demo up-front, add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A **Google Spreadsheets add-on** that makes working with data from **Wikipedia** and **Wikidata** a joy.
 
+## Demo
+
+See the output of the functions in this [Google spreadsheet](https://docs.google.com/spreadsheets/d/1sVduZul787O-bRzuy0UKpRl7bkouxwaIOsxXuJGm6yg/edit?usp=sharing).
+
+Here's a screenshot:
+
 ![Wikipedia Tools for Google Spreadsheets](https://github.com/tomayac/wikipedia-tools-for-google-spreadsheets/blob/master/screenshot.png "Wikipedia Tools for Google Spreadsheets")
 
 ## Installation
@@ -9,14 +15,13 @@ A **Google Spreadsheets add-on** that makes working with data from **Wikipedia**
 Find the [Wikipedia Tools](https://chrome.google.com/webstore/detail/wikipedia-tools/aiilcelhmpllcgkhhpifagfehbddkdfp?utm_source=permalink)
 in the Google Add-on Store and install them by clicking on the blue "+ Free" button.
 
-## Documentation
+## Usage documentation
 
 Once the add-on is installed, click "Add-ons" > "Wikipedia Tools" > "Show documentation"
 in the Google Sheets menu bar to see a sidebar with the full documentation and examples.
 
-## Demo
-
-See the output of the functions in this [Google spreadsheet](https://docs.google.com/spreadsheets/d/1sVduZul787O-bRzuy0UKpRl7bkouxwaIOsxXuJGm6yg/edit?usp=sharing).
+The documentation can also be browsed online without installing the addon, by visiting
+[this page](https://rawgit.com/tomayac/wikipedia-tools-for-google-spreadsheets/master/Documentation.html).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's a screenshot:
 Find the [Wikipedia Tools](https://chrome.google.com/webstore/detail/wikipedia-tools/aiilcelhmpllcgkhhpifagfehbddkdfp?utm_source=permalink)
 in the Google Add-on Store and install them by clicking on the blue "+ Free" button.
 
-## Usage documentation
+## Usage Documentation
 
 Once the add-on is installed, click "Add-ons" > "Wikipedia Tools" > "Show documentation"
 in the Google Sheets menu bar to see a sidebar with the full documentation and examples.


### PR DESCRIPTION
Moved the demo to the beginning of the file, to allow people to immediately get a taste of what this does.
The screenshot is really a static visualization of the demo, so it makes sense to be in the same section.

Also added a link to a live rendered version of the documentation, which allows users to see what's available without first installing the addon.