### PR TITLE
Support redirects for WIKIDATAQID

### DIFF
--- a/Wikipedia.gs.js
+++ b/Wikipedia.gs.js
@@ -1431,14 +1431,18 @@ function WIKIDATAQID(article) {
     if (!title) {
       return '';
     }
-    var url = 'https://www.wikidata.org/w/api.php' +
-        '?action=wbgetentities' +
-        '&sites=' + language + 'wiki' +
+    var url = 'https://' + language + '.wikipedia.org/w/api.php' +
+        '?action=query' +
         '&format=json' +
-        '&props=' + // Empty on purpose
+        '&formatversion=2' +
+        '&redirects=1' +
+        '&prop=pageprops' +
+        '&ppprop=wikibase_item' +
         '&titles=' + encodeURIComponent(title);
     var json = JSON.parse(UrlFetchApp.fetch(url, HEADERS).getContentText());
-    results[0] = Object.keys(json.entities)[0];
+    if ( json.query.pages[0] && json.query.pages[0].pageprops.wikibase_item ) {
+        results[0] = json.query.pages[0].pageprops.wikibase_item;
+    }
   } catch (e) {
     // no-op
   }

--- a/Wikipedia.gs.js
+++ b/Wikipedia.gs.js
@@ -1440,8 +1440,8 @@ function WIKIDATAQID(article) {
         '&ppprop=wikibase_item' +
         '&titles=' + encodeURIComponent(title);
     var json = JSON.parse(UrlFetchApp.fetch(url, HEADERS).getContentText());
-    if ( json.query.pages[0] && json.query.pages[0].pageprops.wikibase_item ) {
-        results[0] = json.query.pages[0].pageprops.wikibase_item;
+    if (json.query.pages[0] && json.query.pages[0].pageprops.wikibase_item) {
+      results[0] = json.query.pages[0].pageprops.wikibase_item;
     }
   } catch (e) {
     // no-op


### PR DESCRIPTION
Use Wikipedia's [query+pageprops](https://www.mediawiki.org/wiki/API:Pageprops) API instead of Wikidata's wbgetentities API for WIKIDATAQID. This way redirects are followed and long-term sheets are less likely to be broken by page moves.

Potential drawbacks / problems:
* I have not tested. (Sorry, no idea how to set up a Google Sheets plugin for development.)
* I believe language names and domain names map 100% but there might be fringe edge cases I'm not aware of.
* Page props are internal detail so the normal API deprecation policy does not apply. That said, the name and existence of this property has not changed for almost a decade now.
* Not sure about performance implications.