### PR TITLE
WIKIDATAQID: clarify documentation

### DIFF
--- a/Documentation.html
+++ b/Documentation.html
@@ -826,7 +826,7 @@ Greater Berlin Act
     </section>
     <section>
       <h2>WIKIDATAQID</h2>
-      <p>Returns the Wikidata qid of the corresponding Wikidata item for an article.</p>
+      <p>Returns the Wikidata qid of the corresponding Wikidata item for a Wikipedia article.</p>
       <h3>Arguments</h3>
       <table>
         <tbody>

--- a/Wikipedia.gs.js
+++ b/Wikipedia.gs.js
@@ -1406,7 +1406,7 @@ function WIKISEARCH(query, opt_didYouMean, opt_namespaces) {
 }
 
 /**
- * Returns the Wikidata qid of the corresponding Wikidata item for an article.
+ * Returns the Wikidata qid of the corresponding Wikidata item for a Wikipedia article.
  *
  * @param {string} article The article in the format "language:Query" ("de:Berlin") to get the Wikidata qid for.
  * @return {string} The Wikidata qid.


### PR DESCRIPTION
Clarify that the search is performed based on Wikipedia articles.