### PR TITLE
Add WIKIDATASEARCH to search for labels/aliases

### DIFF
--- a/Documentation.html
+++ b/Documentation.html
@@ -860,6 +860,41 @@ Greater Berlin Act
       <pre class="code-result"><code>Q64</code></pre>
     </section>
     <section>
+      <h2>WIKIDATASEARCH</h2>
+      <p>Searches for Wikidata entities using Wikidata labels and aliases.</p>
+      <h3>Arguments</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Type</th>
+            <th scope="col">Description</th>
+          </tr>
+          <tr>
+            <td>search</td>
+            <td><code>string</code></td>
+            <td>The search string in the format "language:Query" ("de:Berlin") to get the Wikidata qid for.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Return Values</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th scope="col">Type</th>
+            <th scope="col">Description</th>
+          </tr>
+          <tr>
+            <td><code>string</code></td>
+            <td>The Wikidata qid.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Example</h3>
+      <pre class="code-example"><code>=WIKIDATASEARCH("nb:veldig lett nysnø")</code></pre>
+      <pre class="code-result"><code>Q70596575</code></pre>
+    </section>
+    <section>
       <h2>WIKIDATALABELS</h2>
       <p>Returns the labels for a Wikidata item.</p>
       <h3>Arguments</h3>

--- a/Wikipedia.gs.js
+++ b/Wikipedia.gs.js
@@ -1446,6 +1446,46 @@ function WIKIDATAQID(article) {
 }
 
 /**
+ * Searches for Wikidata entities using Wikidata labels and aliases.
+ *
+ * @param {string} search The search string in the format "language:Query" ("de:Berlin") to get the Wikidata qid for.
+ * @return {string} The Wikidata qid.
+ * @customfunction
+ */
+function WIKIDATASEARCH(search) {
+  'use strict';
+  if (!search) {
+    return '';
+  }
+  var results = [];
+  try {
+    var wbslanguage;
+    var wbssearch;
+    if (search.indexOf(':') !== -1) {
+      wbslanguage = search.split(/:(.+)?/)[0];
+      wbssearch = search.split(/:(.+)?/)[1];
+    } else {
+      wbslanguage = DEFAULT_LANGUAGE;
+      wbssearch = search;
+    }
+    if (!wbssearch) {
+      return '';
+    }
+    var url = 'https://www.wikidata.org/w/api.php' +
+        '?action=query' +
+        '&list=wbsearch' +
+        '&wbslanguage=' + wbslanguage +
+        '&format=json' +
+        '&wbssearch=' + encodeURIComponent(wbssearch);
+    var json = JSON.parse(UrlFetchApp.fetch(url, HEADERS).getContentText());
+    results[0] = json.query.wbsearch[0].title;
+  } catch (e) {
+    // no-op
+  }
+  return results.length > 0 ? results : '';
+}
+
+/**
  * Returns the labels for a Wikidata item.
  *
  * @param {string} qid The Wikidata item's qid to get the labels for.


### PR DESCRIPTION
The existing function `WIKIDATAQID` searches based on Wikipedia articles and fails if the search language does not have a corresponding article.

The added `WIKIDATASEARCH` function makes use of the `wbsearch` query API of Wikidata.

* I have not tested. (Sorry, no idea how to set up a Google Sheets plugin for development.)