### PR TITLE
Support 2D array inputs for WIKIDATAQID.

### DIFF
--- a/Tests.gs.js
+++ b/Tests.gs.js
@@ -24,6 +24,11 @@ function _runTests() {
   var checkResult = function(caller, result) {
     Logger.log(caller + ' ' + (result.length ?
         '✅ OK: ' + JSON.stringify(result) : '❌ Error'));
+    if (Array.isArray(result)) {
+      var pass = result.map(row => row.every(col => col)).every(row => row)
+      Logger.log(caller + ' 2D array check ' + (pass ?
+          '✅ 2D array OK: ' + JSON.stringify(result) : '❌ 2D array Error'));
+    }
   };
 
   var project = 'en.wikipedia';
@@ -65,6 +70,7 @@ function _runTests() {
       article.replace('en:', '')));
 
   checkResult('WIKIDATAQID', WIKIDATAQID(article));
+  checkResult('WIKIDATAQID', WIKIDATAQID([[article], [article]]));
   checkResult('WIKIDATAQID', WIKIDATAQID(article.replace('en:', '')));
 
   checkResult('WIKIDATALOOKUP', WIKIDATALOOKUP('P298', 'AUT'));

--- a/Wikipedia.gs.js
+++ b/Wikipedia.gs.js
@@ -1408,16 +1408,22 @@ function WIKISEARCH(query, opt_didYouMean, opt_namespaces) {
 /**
  * Returns the Wikidata qid of the corresponding Wikidata item for a Wikipedia article.
  *
- * @param {string} article The article in the format "language:Query" ("de:Berlin") to get the Wikidata qid for.
- * @return {string} The Wikidata qid.
+ * @param {string|string[][]} article The article(s) in the format "language:Query" ("de:Berlin") to get the Wikidata qid for.
+ * @return {string|string[][]} The Wikidata qid(s).
  * @customfunction
  */
 function WIKIDATAQID(article) {
+  return Array.isArray(article) ?
+      article.map(row => row.map(cell => WIKIDATAQID_NOTARRAY_(cell))) :
+      WIKIDATAQID_NOTARRAY_(article);
+}
+
+function WIKIDATAQID_NOTARRAY_(article) {
   'use strict';
   if (!article) {
     return '';
   }
-  var results = [];
+  var results = '';
   try {
     var language;
     var title;
@@ -1441,12 +1447,12 @@ function WIKIDATAQID(article) {
         '&titles=' + encodeURIComponent(title);
     var json = JSON.parse(UrlFetchApp.fetch(url, HEADERS).getContentText());
     if (json.query.pages[0] && json.query.pages[0].pageprops.wikibase_item) {
-      results[0] = json.query.pages[0].pageprops.wikibase_item;
+      results = json.query.pages[0].pageprops.wikibase_item;
     }
   } catch (e) {
     // no-op
   }
-  return results.length > 0 ? results : '';
+  return results;
 }
 
 /**


### PR DESCRIPTION
_This is related to #41_

This is the first PR for broad support for your Wikipedia functions to support array inputs.

* Example usage: `==WIKIDATAQID(A6:A10)`.
* Example spreadsheet: https://docs.google.com/spreadsheets/d/10pFViQJSXBN6lbryWmB2xG4EkggKdGkyzn3NLKXVEnk/edit#gid=0

The goal of this PR is to establish a baseline for how we'd like each function to be updated, and then update many more.

FYI, this is my first ever pull request :)